### PR TITLE
add reference to Zotero BibTex style in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ ___
 
    * [Export `.bib` from Mendeley](https://blog.mendeley.com/2011/10/25/howto-use-mendeley-to-create-citations-using-latex-and-bibtex/)
    * [Export `.bib` from Zotero](https://libguides.mit.edu/ld.php?content_id=34248570)
+    * Or set your citation style to [BibTex](https://www.zotero.org/styles?q=id%3Abibtex) in Word/Gdocs, and copy the reference list into a `.bib` file
    * [Export `.bib` from EndNote](https://www.reed.edu/cis/help/LaTeX/EndNote.html). Note: Please export full first names by either [choosing an output style that does so by default (e.g. in MLA style)](https://canterbury.libguides.com/endnote/basics-output) 
    * [Export `.bib` from Read Cube Papers](https://support.papersapp.com/support/solutions/articles/30000024634-how-can-i-export-references-from-readcube-papers-)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ ___
 
    * [Export `.bib` from Mendeley](https://blog.mendeley.com/2011/10/25/howto-use-mendeley-to-create-citations-using-latex-and-bibtex/)
    * [Export `.bib` from Zotero](https://libguides.mit.edu/ld.php?content_id=34248570)
-    * Or set your citation style to [BibTex](https://www.zotero.org/styles?q=id%3Abibtex) in Word/Gdocs, and copy the reference list into a `.bib` file
+     * Or set your citation style to [BibTex](https://www.zotero.org/styles?q=id%3Abibtex) in Word/Gdocs, and copy the reference list into a `.bib` file
    * [Export `.bib` from EndNote](https://www.reed.edu/cis/help/LaTeX/EndNote.html). Note: Please export full first names by either [choosing an output style that does so by default (e.g. in MLA style)](https://canterbury.libguides.com/endnote/basics-output) 
    * [Export `.bib` from Read Cube Papers](https://support.papersapp.com/support/solutions/articles/30000024634-how-can-i-export-references-from-readcube-papers-)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ ___
 
    * [Export `.bib` from Mendeley](https://blog.mendeley.com/2011/10/25/howto-use-mendeley-to-create-citations-using-latex-and-bibtex/)
    * [Export `.bib` from Zotero](https://libguides.mit.edu/ld.php?content_id=34248570)
-     * Or set your citation style to [BibTex](https://www.zotero.org/styles?q=id%3Abibtex) in Word/Gdocs, and copy the reference list into a `.bib` file. Make sure you change `et-al-min` and `et-al-first` to something large (like 100) to avoid the last author being listed as 'et al.'
+     * Or: set your citation style to [BibTex](https://www.zotero.org/styles?q=id%3Abibtex) in Word/Gdocs, and copy the reference list into a `.bib` file. 
+       * Make sure you edit `Zotero/styles/bibtex.csl`: change `et-al-min` and `et-al-first` to something large (like 100) to avoid the last author being listed as 'et al.' 
+       * Remove the line `text variable="abstract" prefix=" abstractNote={" suffix="}"/>` to avoid the `.bib` file getting very large.
    * [Export `.bib` from EndNote](https://www.reed.edu/cis/help/LaTeX/EndNote.html). Note: Please export full first names by either [choosing an output style that does so by default (e.g. in MLA style)](https://canterbury.libguides.com/endnote/basics-output) 
    * [Export `.bib` from Read Cube Papers](https://support.papersapp.com/support/solutions/articles/30000024634-how-can-i-export-references-from-readcube-papers-)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ ___
 
    * [Export `.bib` from Mendeley](https://blog.mendeley.com/2011/10/25/howto-use-mendeley-to-create-citations-using-latex-and-bibtex/)
    * [Export `.bib` from Zotero](https://libguides.mit.edu/ld.php?content_id=34248570)
-     * Or set your citation style to [BibTex](https://www.zotero.org/styles?q=id%3Abibtex) in Word/Gdocs, and copy the reference list into a `.bib` file
+     * Or set your citation style to [BibTex](https://www.zotero.org/styles?q=id%3Abibtex) in Word/Gdocs, and copy the reference list into a `.bib` file. Make sure you change `et-al-min` and `et-al-first` to something large (like 100) to avoid the last author being listed as 'et al.'
    * [Export `.bib` from EndNote](https://www.reed.edu/cis/help/LaTeX/EndNote.html). Note: Please export full first names by either [choosing an output style that does so by default (e.g. in MLA style)](https://canterbury.libguides.com/endnote/basics-output) 
    * [Export `.bib` from Read Cube Papers](https://support.papersapp.com/support/solutions/articles/30000024634-how-can-i-export-references-from-readcube-papers-)
 


### PR DESCRIPTION
When exporting my reference list from Zotero, I found the BibTex file export a bit cumbersome (since I had to manually go through my library and select those references I'm citing in a manuscript). 
When working with the Zotero connector for Word or Google Docs, you can additionally change the citation style to BibTex, and then simply copy the bibliography into a `.bib` file. I've added a short link to this option.